### PR TITLE
Display server history in Modal

### DIFF
--- a/src/components/BackendPanel.vue
+++ b/src/components/BackendPanel.vue
@@ -3,12 +3,7 @@
 		<div class="server-toolbar" v-show="$config.allowServerChange">
 			<h3>Server:</h3>
 			<input id="serverUrl" ref="serverUrl" list="serverUrls" value="" />
-			<span id="serverUrlsContainer" title="Select previously used server">
-				<select id="serverUrls" ref="serverUrls" @change="updateServerUrlFromSelect">
-					<option v-for="url in serverUrls" :key="url" :value="url">{{ url }}</option>
-				</select>
-				<i class="fas fa-book" id="serverUrlsIcon"></i>
-			</span>
+			<button @click="showServerSelector" title="Select previously used server"><i class="fas fa-book"></i></button>
 			<button @click="updateServerUrlFromInput" title="Change server"><i class="fas fa-check"></i></button>
 		</div>
 		<div class="info-toolbar">
@@ -78,6 +73,10 @@ export default {
 			return this.openEO.Capabilities.processes() && this.processes.length > 0;
 		},
 
+		showServerSelector() {
+			EventBus.$emit('showComponentModal', 'Select previously used server', 'ServerSelector', {serverUrls: this.serverUrls, callback: this.updateServerUrlTo})
+		},
+
 		changeServer(url) {
 			this.$refs.serverUrl.value = url;
 			if (this.serverUrls.indexOf(url) === -1) {
@@ -105,8 +104,7 @@ export default {
 			}
 		},
 
-		updateServerUrlFromSelect() {
-			var newUrl = this.$refs.serverUrls.value;
+		updateServerUrlTo(newUrl) {
 			this.$refs.serverUrl.value = newUrl;
 			this.updateServerUrlFromInput();
 		},
@@ -233,19 +231,6 @@ h3 {
 #serverUrl {
 	width: 60%;
 	font-family: monospace;
-}
-#serverUrls {
-	width: 10px;
-}
-#serverUrlsContainer {
-	position: relative;
-}
-#serverUrlsIcon {
-	position: absolute;
-	left: 8px;
-	top: 3px;
-	background-color: white;
-	pointer-events: none;
 }
 .server-toolbar {
 	margin-bottom: 5px;

--- a/src/components/Modal.vue
+++ b/src/components/Modal.vue
@@ -16,11 +16,13 @@
 <script>
 import EventBus from '../eventbus.js';
 import List from './List.vue';
+import ServerSelector from './ServerSelector.vue';
 
 export default {
 	name: 'Modal',
 	components:  {
-		List
+		List,
+		ServerSelector
 	},
 	data() {
 		return {

--- a/src/components/ServerSelector.vue
+++ b/src/components/ServerSelector.vue
@@ -1,0 +1,31 @@
+<template>
+    <ul>
+        <li v-for="url in serverUrls" :key="url">
+            <span @click="submit(url)">{{ url }}</span>
+        </li>
+    </ul>
+</template>
+
+<script>
+export default {
+    name: 'ServerSelector',
+    props: ['serverUrls', 'callback'],
+    methods: {
+        submit(url) {
+            this.callback(url);
+            if(this.$parent && this.$parent.$options.name == 'Modal') {
+                this.$parent.close();
+            }
+        }
+    }
+};
+</script>
+
+<style>
+    li {
+        padding: 5px 0px;
+    }
+    li span {
+        cursor: pointer;
+    }
+</style>

--- a/src/eventbus.js
+++ b/src/eventbus.js
@@ -30,6 +30,7 @@ Shows a modal with the specified title and body contents. $body must be a string
 ## showComponentModal(string $title, string $compname, object $props)
 Shows a modal with the specified title and an instance of the $compname component.
 The component can be supplied with props by passing them as an object with the props' names as the keys and the props' contents as the values, e.g. {propname1: 'content', propname2: {foo: 'bar'}}
+The component to be used must be known (i.e. imported and declared) in the Modal component.
 
 ## showDataDisplayModal(string $title, object $data)
 Shows a modal with the specified title and the contents of the data object as the body, but rendered as a more readable list via the List component.


### PR DESCRIPTION
Adds a new component named ServerSelector that displays a given list and calls a callback function when one of the items is selected.
This component is displayed in a Modal to provide the "select previously used server" function, replacing the combobox hack that looked pretty in Ubuntu but probably horrible everywhere else.