### PR TITLE
Improve UI for loading saved scripts

### DIFF
--- a/src/components/BackendPanel.vue
+++ b/src/components/BackendPanel.vue
@@ -75,7 +75,7 @@ export default {
 
 		showServerSelector() {
 			EventBus.$emit('showComponentModal', 'Select previously used server', 'List', {
-				items: this.serverUrls,
+				dataSource: this.serverUrls,
 				actions: [
 					{
 						callback: (url) => this.updateServerUrlTo(url) || true,  // return true to close the modal

--- a/src/components/List.vue
+++ b/src/components/List.vue
@@ -13,7 +13,12 @@
 import EventBus from '../eventbus.js';
 export default {
     name: 'List',
-    props: ['items', 'actions'],
+    props: ['dataSource', 'actions'],
+    computed: {
+        items() {
+            return (typeof this.dataSource == 'function' ? this.dataSource() : this.dataSource);
+        }
+    },
     methods: {
         doAction(callback, item) {
             const closeAfterCompletion = callback(item);

--- a/src/components/SourceEnvironment.vue
+++ b/src/components/SourceEnvironment.vue
@@ -5,7 +5,7 @@
 			<div class="sourceToolbar">
 				<button @click="executeScript" title="Run current script and view results" v-if="openEO.Capabilities.executeJob()" class="executeScript"><i class="fas fa-play"></i></button>
 				<button @click="newScript" title="Clear current script / New script"><i class="fas fa-file"></i></button>
-				<button @click="loadScript" title="Load script from local storage"><i class="fas fa-folder-open"></i></button>
+				<button @click="loadScript()" title="Load script from local storage"><i class="fas fa-folder-open"></i></button>
 				<button @click="saveScript" title="Save script to local storage"><i class="fas fa-save"></i></button>
 				<button @click="downloadScript" title="Download script"><i class="fas fa-download"></i></button>
 			</div>
@@ -28,6 +28,11 @@ import CodeMirror from 'codemirror';
 export default {
 	name: 'SourceEnvironment',
 	props: ['openEO'],
+	computed: {
+		savedScriptNames() {
+			return Object.keys(this.savedScripts);
+		}
+	},
 	data() {
 		return {
 			scriptName: '',
@@ -136,18 +141,34 @@ OpenEO.Editor.ProcessGraph = OpenEO.ImageCollection.create('Sentinel2A-L1C')
 			}
 		},
 		
-		loadScript() {
-			var name = prompt("Name of the script to load:");
-			if (!name) {
-				return;
-			}
-			if (code) {
-				this.editor.setValue(code);
-				this.scriptName = name;
-			}
-			else {
-				this.$utils.info(this, 'No script with the name "' + name + '" found.');
+		loadScript(name = undefined) {
+			if(name != undefined) {
 				var code = this.savedScripts[name];
+				if (code) {
+					this.editor.setValue(code);
+					this.scriptName = name;
+					return true;  // to close the modal
+				}
+				else {
+					this.$utils.info(this, 'No script with the name "' + name + '" found.');
+					return false;  // to keep the modal open
+				}
+			} else {
+				EventBus.$emit('showComponentModal', 'Select script to load', 'List', {
+					items: this.savedScriptNames,
+					actions: [
+						{
+							callback: this.loadScript,
+							icon: 'check',
+							title: 'Load script'
+						},
+						{
+							callback: this.deleteScript,
+							icon: 'trash',
+							title: 'Delete script'
+						}
+					]
+				});
 			}
 		},
 		

--- a/src/components/SourceEnvironment.vue
+++ b/src/components/SourceEnvironment.vue
@@ -31,6 +31,7 @@ export default {
 	data() {
 		return {
 			scriptName: '',
+			savedScripts: {},
 			editorOptions: {
 				mode: 'javascript',
 				indentUnit: 4,
@@ -47,11 +48,23 @@ OpenEO.Editor.ProcessGraph = OpenEO.ImageCollection.create('Sentinel2A-L1C')
 	.max_time();`
 		}
 	},
+	watch: {
+		savedScripts: {
+			handler: function(newVal, oldVal) {
+				localStorage.setItem("savedScripts", JSON.stringify(newVal));
+			},
+			deep: true
+		}
+	},
 	mounted() {
 		this.editor = CodeMirror(document.getElementById('sourceCodeEditor'), this.editorOptions);
 		this.editor.setValue(this.defaultScript);
 		EventBus.$on('addToSource', this.insertToEditor);
 		EventBus.$on('evalScript', this.evalScript);
+		var storedScripts = localStorage.getItem("savedScripts");
+		if (storedScripts !== null) {
+			this.savedScripts = JSON.parse(storedScripts);
+		}
 	},
 	methods: {
 		evalScript(callback) {
@@ -95,7 +108,7 @@ OpenEO.Editor.ProcessGraph = OpenEO.ImageCollection.create('Sentinel2A-L1C')
 		},
 
 		storageName(name) {
-			return "script." + name.replace('.', '_');
+			return name.replace('.', '_');
 		},
 
 		executeScript() {
@@ -128,13 +141,13 @@ OpenEO.Editor.ProcessGraph = OpenEO.ImageCollection.create('Sentinel2A-L1C')
 			if (!name) {
 				return;
 			}
-			var code = localStorage.getItem(this.storageName(name));
 			if (code) {
 				this.editor.setValue(code);
 				this.scriptName = name;
 			}
 			else {
 				this.$utils.info(this, 'No script with the name "' + name + '" found.');
+				var code = this.savedScripts[name];
 			}
 		},
 		
@@ -143,7 +156,7 @@ OpenEO.Editor.ProcessGraph = OpenEO.ImageCollection.create('Sentinel2A-L1C')
 			if (!name) {
 				return;
 			}
-			localStorage.setItem(this.storageName(name), this.editor.getValue());
+			this.$set(this.savedScripts, this.storageName(name), this.editor.getValue());
 			this.scriptName = name;
 		},
 		
@@ -153,6 +166,10 @@ OpenEO.Editor.ProcessGraph = OpenEO.ImageCollection.create('Sentinel2A-L1C')
 				name = "openeo-script";
 			}
 			this.$utils.downloadData(this.editor.getValue(), name + ".js", "text/javascript");
+		},
+
+		deleteScript(name) {
+			this.$delete(this.savedScripts, name);
 		},
 
 		insertToEditor(text) {
@@ -170,12 +187,12 @@ OpenEO.Editor.ProcessGraph = OpenEO.ImageCollection.create('Sentinel2A-L1C')
 .sourceHeader h3 {
 	margin-top: 1px;
 	float: left;
-	width: 70%;
+	width: 65%;
 }
 .sourceToolbar {
 	text-align: right;
 	float: right;
-	width: 30%;
+	width: 35%;
 }
 .sourceHeader {
 	padding: 5px;

--- a/src/components/SourceEnvironment.vue
+++ b/src/components/SourceEnvironment.vue
@@ -139,7 +139,7 @@ export default {
 				}
 			} else {
 				EventBus.$emit('showComponentModal', 'Select script to load', 'List', {
-					items: this.savedScriptNames,
+					dataSource: () => this.savedScriptNames,
 					actions: [
 						{
 							callback: this.loadScript,


### PR DESCRIPTION
The app now shows a modal with a list of all available scripts that can be selected instead of just prompting for the script name.

Changes:
- Make saving of scripts to LocalStorage analogous to server urls
- Replace prompt for script name with comfy list in modal
- Allow functions as data source for List component (to fix display bug when removing items from the list)