### PR TITLE
Add Dockerfile

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,5 @@
+dist
+Dockerfile
+node_modules
+.dockerignore
+.git

--- a/.dockerignore
+++ b/.dockerignore
@@ -1,5 +1,12 @@
+# Contains files which should be ignored in the build context.
+
+# This includes large files and folders which might exist locally
+# but are not needed during docker build to speed up build time
 dist
-Dockerfile
 node_modules
-.dockerignore
 .git
+
+# and files which are equally not needed and would break the
+# build cache at an early step (COPY . ...) if changed.
+Dockerfile
+.dockerignore

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,13 @@
+FROM node:16-alpine3.11 as build
+
+# Copy source code
+COPY . /src/openeo-web-editor
+WORKDIR /src/openeo-web-editor
+
+# Build
+RUN npm install
+RUN npm run build
+
+# Copy build folder and run with nginx
+FROM nginx:1.20.1-alpine
+COPY --from=build /src/openeo-web-editor/dist /usr/share/nginx/html

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ You can also build the files yourself and deploy them to any web host:
 3. Open a command line window and go to the directory which contains the cloned/downloaded web editor files.
 4. Configure the web editor by editing `config.js` and `vue.config.js` to suit your needs.
 6. Install the dependencies by executing `npm install` on the command line
-7. 
+7.
     * Development: Run the development server by executing `npm start`.
     * Deployment: Build the project by executing `npm run build`. Afterwards upload the content of the `dist` folder to your server.
 
@@ -37,3 +37,16 @@ Example: <https://editor.openeo.org?server=https://earthengine.openeo.org&discov
 
 ## License
 This project is licensed under the Apache 2.0 license - see the [LICENSE.md](LICENSE.md) file for details.
+
+## Docker
+This repository contains a Dockerfile. It can be build with
+```
+docker build . -t openeo-web-editor
+```
+and then tested locally with
+```
+docker run -p 8080:80 openeo-web-editor
+```
+After sucessfull startup, the webeditor can be reached locally at http://127.0.0.1:8080/
+
+More startup information can be seen at the [official nginx docker image](https://hub.docker.com/_/nginx/) which is used.


### PR DESCRIPTION
This PR suggests to add a simple Dockerfile building the openeo-web-editor and then copying the build resources into an nginx.
To bulid it, `docker build . -t openeo-web-editor` can be executed, while `docker run -p 8080:80 openeo-web-editor` will start it to test locally at `http://127.0.0.1:8080/`

This could help for easy deployment when no configuration is needed. It could then be connected to an automatic build on dockerhub to always have the latest version.

I think it is plain + general enough to be hosted here at the official repository. What do you think?