### PR TITLE
Add GHA for docker

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -47,6 +47,6 @@ jobs:
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           context: .
-          file: docker/Dockerfile
+          file: Dockerfile
       - name: Image digest
         run: echo ${{ steps.docker_build.outputs.digest }}

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,0 +1,52 @@
+# Workflow to build and push docker images
+# On push to branch, take care of sha-ref tag (e.g. sha-ad132f5)
+# On release, take care of latest and release tags (e.g. 1.2.3)
+
+name: Docker build and push
+
+on:
+  push:
+    branches: [master, gha-docker]
+    tags: ['*.*.*']
+  release:
+    types: [published]
+
+jobs:
+  docker:
+    name: docker build and push
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+      - name: Create image and tag names
+        id: meta
+        uses: docker/metadata-action@v3
+        with:
+          images: mundialis/openeo-web-editor
+          tags: |
+            type=ref,event=tag
+            type=sha
+          flavor: |
+            latest=auto
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v1
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v1
+      - name: Login to DockerHub
+        uses: docker/login-action@v1
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN  }}
+      - name: Build and push
+        id: docker_build
+        uses: docker/build-push-action@v2
+        with:
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          context: .
+          file: docker/Dockerfile
+      - name: Image digest
+        run: echo ${{ steps.docker_build.outputs.digest }}

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -6,7 +6,7 @@ name: Docker build and push
 
 on:
   push:
-    branches: [master, gha-docker]
+    branches: [master]
     tags: ['*.*.*']
   release:
     types: [published]


### PR DESCRIPTION
This PR adds a github action to build and push the Dockerimage from this repository to Dockerhub. It contains a workflow which runs for push to master branch and creation of releases.

- for master branch it will create a docker image with tag containing sha-ref (e.g. sha-ad132f5)
- for releases it will create a docker image with tag latest
- for releases it will create a docker image with tag containing the released version (e.g. 1.2.3)

For this workflow to work, credentials to dockerhub are needed. In [the repository settings](https://github.com/Open-EO/openeo-web-editor/settings/secrets/actions) the secrets DOCKERHUB_TOKEN and DOCKERHUB_USERNAME would need to be created. For the values I would be willing to store mine (mmacata) or these of a machine user we use (mundialisdev) so no extra setup would be required but if it suits better, a new / different user can be created of course. The user is shown in Dockerhub, like it can be seen [here](https://hub.docker.com/repository/docker/mundialis/openeo-web-editor/tags?page=1&ordering=last_updated) for tag `sha-2da70e0`.

As docker repository, I used mundialis/openeo-web-editor, as this was the repository which had autobuild set up before and appeared in the checks for commits / pull requests in the past and I have access to. On Dockerhub I found no gerneral openeo organization but [`openeor`](https://hub.docker.com/u/openeor) and [`openeobs`](https://hub.docker.com/u/openeobs). `openeor` looks like specific to `r` Code and `openeobs` was updated last 3 years ago. So here - as well as with credentials - if it suits better, another repository can be used but I don't know which would fit. It is also possible to create an `openeo` organization on Dockerhub, if other repositories from openeo will benefit from it as well!?

I marked this PR as draft until the question about credentials is solved. Before any are added, this check would fail and should therefore not be merged.