### PR TITLE
Add an intro for the model builder #269

### DIFF
--- a/src/Page.vue
+++ b/src/Page.vue
@@ -255,10 +255,24 @@ button:disabled i {
 	color: #555;
 }
 
-tt, .vue-component.styled-description code {
+tt, .vue-component.styled-description code, p code {
 	color: maroon;
 	display: inline-block;
 	padding: 0 0.1em 0 0.3em;
+}
+
+kbd {
+	margin: 0px 0.1em;
+	padding: 0.2em 0.6em 0.1em 0.6em;
+	border-radius: 3px;
+	border: 1px solid rgb(204, 204, 204);
+	color: rgb(51, 51, 51);
+	line-height: 1.33em;
+	font-size: 0.9em;
+	display: inline-block;
+	box-shadow: 0px 1px 0px rgba(0,0,0,0.2), inset 0px 0px 0px 2px #ffffff;
+	background-color: rgb(247, 247, 247);
+	text-shadow: 0 1px 0 #fff;
 }
 
 #activeRequests {

--- a/src/components/Editor.vue
+++ b/src/components/Editor.vue
@@ -1,7 +1,7 @@
 <template>
 	<Tabs class="editor" ref="tabs" id="customProcessContent" position="bottom">
 		<Tab id="visual" name="Visual Model" icon="fa-project-diagram" :selected="true" :allowShow="canSwitchView" @show="showModel">
-			<VisualEditor class="visualEditorTab" ref="graphBuilder" :editable="editable" :parent="parent" :parentSchema="parentSchema" :value="modelValue" @input="commit" @error="onError" :title="title" :id="id + '_visual'" :showDiscoveryToolbar="showDiscoveryToolbar" :defaultValue="defaultValue">
+			<VisualEditor class="visualEditorTab" ref="graphBuilder" :editable="editable" :parent="parent" :parentSchema="parentSchema" :value="modelValue" @input="commit" @error="onError" :title="title" :id="id + '_visual'" :showDiscoveryToolbar="showDiscoveryToolbar" :showIntro="showIntro" :defaultValue="defaultValue">
 				<template #file-toolbar><slot name="file-toolbar"></slot></template>
 				<template #toolbar><slot name="toolbar"></slot></template>
 			</VisualEditor>
@@ -55,6 +55,10 @@ export default {
 			default: null
 		},
 		showDiscoveryToolbar: {
+			type: Boolean,
+			default: false
+		},
+		showIntro: {
 			type: Boolean,
 			default: false
 		},

--- a/src/components/IDE.vue
+++ b/src/components/IDE.vue
@@ -16,7 +16,7 @@
 				<Pane id="workspace" :size="splitpaneSizeH[1]">
 					<Splitpanes class="default-theme" horizontal @resize="resized" @pane-maximize="resized">
 						<Pane id="editor" :size="splitpaneSizeV[0]">
-							<Editor ref="editor" class="mainEditor tour-ide-editor" id="main" :value="process" @input="updateEditor" :title="contextTitle">
+							<Editor ref="editor" class="mainEditor tour-ide-editor" id="main" :value="process" @input="updateEditor" :title="contextTitle" showIntro>
 								<template #file-toolbar>
 									<button type="button" @click="importProcess" title="Import process from external source"><i class="fas fa-cloud-download-alt"></i></button>
 									<button type="button" v-show="saveSupported" :disabled="!hasProcess" @click="saveProcess" :title="'Save to ' + contextTitle"><i class="fas fa-save"></i></button>
@@ -120,6 +120,7 @@ export default {
 		this.listen('showDataForm', this.showDataForm);
 		this.listen('editProcess', this.editProcess);
 		this.listen('showLogin', this.login);
+		this.listen('importProcess', this.importProcess);
 
 		this.resizeListener = event => this.resized(event);
 		window.addEventListener('resize', this.resizeListener);

--- a/src/components/VisualEditor.vue
+++ b/src/components/VisualEditor.vue
@@ -26,6 +26,28 @@
 		<div class="editorSplitter">
 			<DiscoveryToolbar v-if="(showDiscoveryToolbar || isFullScreen) && editable" class="discoveryToolbar" :onAddProcess="insertProcess" />
 			<div class="graphBuilder" @drop="onDrop" @dragover="allowDrop">
+				<div v-if="showHelpOverlay" class="model-overlay">
+					<h2>Welcome!</h2>
+					<p>What you are seeing in this area of the {{ $config.appName }} is the visual model builder.</p>
+					<p>You can start building your model by dragging collections, processes etc. from the left area and dropping them here.</p>
+					<p>Alternatively, you can also import existing processes into the model builder:</p>
+					<ul>
+						<li>Paste the JSON from your clipboard by clicking <button type="button" @click="paste" title="Paste from clipboard"><i class="fas fa-paste"></i></button> or use <kbd>STRG</kbd> + <kbd>V</kbd> (Windows, Linux) or <kbd>⌘</kbd> + <kbd>V</kbd> (MacOS) when the model builder is in focus.</li>
+						<li>Drag and drop a JSON file from your computer</li>
+						<li>Import a JSON file from your computer or another source such as the internet by clicking <button type="button" @click="importProcess" title="Import process from external source"><i class="fas fa-cloud-download-alt"></i></button></li>
+					</ul>
+					<p>
+						You can also import the processes from the Python and R client.
+						You need to export your process to JSON first:
+						<ul>
+							<li>In Python use <a href="https://open-eo.github.io/openeo-python-client/cookbook/tricks.html#process-graph-export" target="_blank"><code>result.to_json()</code></a></li>
+							<li>In R use <a href="https://open-eo.github.io/openeo-r-client/reference/index.html" target="_blank"><code>toJSON(as(result, "Process"))</code></a></li>
+						</ul>
+						In both cases, <code>result</code> is your last return value from a data cube process such as <code>save_result</code>.
+						For more details, please read the corresponding chapter in the <a href="https://openeo.org/documentation/1.0/cookbook/#output-process-as-json" target="_blank">openEO cookbook</a>.
+					</p>
+					<p>Once you start interacting with this area, this message will disappear.</p>
+				</div>
 				<ModelBuilder
 					ref="blocks"
 					:editable="editable"
@@ -90,6 +112,10 @@ export default {
 			type: Boolean,
 			default: false
 		},
+		showIntro: {
+			type: Boolean,
+			default: false
+		},
 		title: {
 			type: String
 		},
@@ -105,6 +131,7 @@ export default {
 	},
 	data() {
 		return {
+			showHelpOverlay: this.showIntro,
 			canUndo: false,
 			canRedo: false,
 			compactMode: false,
@@ -117,6 +144,9 @@ export default {
 		value: {
 			immediate: true,
 			handler(value) {
+				if (value) {
+					this.showHelpOverlay = false;
+				}
 				if (this.initialNode && Utils.isObject(value) && Utils.isObject(value.process_graph)) {
 					try {
 						let node = this.initialNode;
@@ -142,6 +172,18 @@ export default {
 			}
 			this.$emit('input', value);
 		},
+		async paste() {
+			try {
+				const text = await navigator.clipboard.readText();
+				let process = JSON.parse(text);
+				await this.$refs.blocks.import(process);
+			} catch(error) {
+				Utils.exception(this, error, 'Paste Error');
+			}
+		},
+		importProcess() {
+			this.emit('importProcess');
+		},
 		errorHandler(message, title = null) {
 			Utils.exception(this, message, title)
 		},
@@ -153,6 +195,7 @@ export default {
 			this.canRedo = !!history[index+1];
 		},
 		allowDrop(event) {
+			this.showHelpOverlay = false;
 			event.preventDefault();
 		},
 		onDrop(event) {
@@ -574,49 +617,67 @@ export default {
 }
 </script>
 
-<style>
+<style lang="scss">
 .visualEditor {
 	background-color: white;
 	height: 100%;
 	display: flex;
 	flex-direction: column;
-}
 
-.visualEditor .vue-component.model-builder {
-	min-height: 100px;
-	min-width: 100px;
-}
+	.vue-component.model-builder {
+		min-height: 100px;
+		min-width: 100px;
+	}
 
-.visualEditor .editorSplitter {
-	display: flex;
-	flex-direction: row-reverse;
-	flex-grow: 1;
-	height: 100%;
-	overflow: hidden;
-}
+	.model-overlay {
+		position: absolute;
+		width: 100%;
+		height: 100%;
+		left: 0;
+		top: 0;
+		color: #555;
+		z-index: 5;
+		padding: 1em;
+		overflow: auto;
+		box-sizing: border-box;
+		line-height: 1.33em;
 
-.visualEditor .discoveryToolbar {
-	width: 25%;
-	min-width: 150px;
-	border-left: 1px solid #ddd;
-}
-.visualEditor.fullscreen .discoveryToolbar {
-	width: 15%;
-	min-width: 250px;
+		> p:first-of-type {
+			margin-top: 0;
+		}
+	}
+
+	.discoveryToolbar {
+		width: 25%;
+		min-width: 150px;
+		border-left: 1px solid #ddd;
+	}
+	.editorSplitter {
+		display: flex;
+		flex-direction: row-reverse;
+		flex-grow: 1;
+		height: 100%;
+		overflow: hidden;
+	}
+
+	&.fullscreen {
+		display: flex;
+		flex-direction: column;
+
+		.discoveryToolbar {
+			width: 15%;
+			min-width: 250px;
+		}
+		.editorSplitter {
+			height: 100%;
+		}
+	}
 }
 
 .graphBuilder {
 	height: 100%;
 	flex-grow: 1;
-}
-
-.visualEditor.fullscreen {
-	display: flex;
-	flex-direction: column;
-}
-
-.visualEditor.fullscreen .editorSplitter {
-	height: 100%;
+	position: relative;
 }
 
 .compactMode {

--- a/src/components/VisualEditor.vue
+++ b/src/components/VisualEditor.vue
@@ -32,7 +32,7 @@
 					<p>You can start building your model by dragging collections, processes etc. from the left area and dropping them here.</p>
 					<p>Alternatively, you can also import existing processes into the model builder:</p>
 					<ul>
-						<li>Paste the JSON from your clipboard by clicking <button type="button" @click="paste" title="Paste from clipboard"><i class="fas fa-paste"></i></button> or use <kbd>STRG</kbd> + <kbd>V</kbd> (Windows, Linux) or <kbd>⌘</kbd> + <kbd>V</kbd> (MacOS) when the model builder is in focus.</li>
+						<li>Paste the JSON from your clipboard by clicking <button type="button" @click="paste" title="Paste from clipboard"><i class="fas fa-paste"></i></button> or use <kbd>CTRL</kbd> + <kbd>V</kbd> (Windows, Linux) or <kbd>⌘</kbd> + <kbd>V</kbd> (MacOS) when the model builder is in focus.</li>
 						<li>Drag and drop a JSON file from your computer</li>
 						<li>Import a JSON file from your computer or another source such as the internet by clicking <button type="button" @click="importProcess" title="Import process from external source"><i class="fas fa-cloud-download-alt"></i></button></li>
 					</ul>
@@ -40,7 +40,7 @@
 						You can also import the processes from the Python and R client.
 						You need to export your process to JSON first:
 						<ul>
-							<li>In Python use <a href="https://open-eo.github.io/openeo-python-client/cookbook/tricks.html#process-graph-export" target="_blank"><code>result.to_json()</code></a></li>
+							<li>In Python use <a href="https://open-eo.github.io/openeo-python-client/cookbook/tricks.html#process-graph-export" target="_blank"><code>print(result.to_json())</code></a></li>
 							<li>In R use <a href="https://open-eo.github.io/openeo-r-client/reference/index.html" target="_blank"><code>toJSON(as(result, "Process"))</code></a></li>
 						</ul>
 						In both cases, <code>result</code> is your last return value from a data cube process such as <code>save_result</code>.


### PR DESCRIPTION
I started with an overview that users get on "startup" when the model builder is empty. Once you start interacting with the canvas, e.g. by dragging something, it disappears.

![image](https://user-images.githubusercontent.com/8262166/187773507-72f0286d-6a0b-4358-af5a-0794066650be.png)

What do you think? Does this help? Is this confusing? What can we improve? Do the explanations for Python/R work?