### PR TITLE
Pagination support #331

### DIFF
--- a/config.js
+++ b/config.js
@@ -105,5 +105,8 @@ export default {
 	// Show or hide experimental and/or deprecated entites by default (e.g. processes, collections)
 	showExperimentalByDefault: false,
 	showDeprecatedByDefault: false,
+
+	// number of items to show per page in the UI (jobs, services, files, UDPs) - null to disable pagination
+	pageLimit: 50,
 	
 };

--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
     "@openeo/js-client": "^2.7.0",
     "@openeo/js-commons": "^1.5.0",
     "@openeo/js-processgraphs": "^1.4.1",
-    "@openeo/vue-components": "^2.18.0",
+    "@openeo/vue-components": "^2.18.1",
     "@radiantearth/stac-fields": "^1.5.0-beta.2",
     "@radiantearth/stac-migrate": "^2.0.0-beta.1",
     "@tmcw/togeojson": "^5.5.0",

--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
     "@openeo/js-client": "^2.7.0",
     "@openeo/js-commons": "^1.5.0",
     "@openeo/js-processgraphs": "^1.4.1",
-    "@openeo/vue-components": "open-EO/openeo-vue-components#load-more-table",
+    "@openeo/vue-components": "^2.18.0",
     "@radiantearth/stac-fields": "^1.5.0-beta.2",
     "@radiantearth/stac-migrate": "^2.0.0-beta.1",
     "@tmcw/togeojson": "^5.5.0",

--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
     "@openeo/js-client": "^2.7.0",
     "@openeo/js-commons": "^1.5.0",
     "@openeo/js-processgraphs": "^1.4.1",
-    "@openeo/vue-components": "^2.17.0",
+    "@openeo/vue-components": "open-EO/openeo-vue-components#load-more-table",
     "@radiantearth/stac-fields": "^1.5.0-beta.2",
     "@radiantearth/stac-migrate": "^2.0.0-beta.1",
     "@tmcw/togeojson": "^5.5.0",

--- a/src/Page.vue
+++ b/src/Page.vue
@@ -19,7 +19,6 @@
 import EventBusMixin from './components/EventBusMixin.js';
 import Utils from './utils';
 import ConnectForm from './components/ConnectForm.vue';
-import { Environment } from '@openeo/js-client';
 
 export default {
 	name: 'openeo-web-editor',

--- a/src/components/CustomProcessPanel.vue
+++ b/src/components/CustomProcessPanel.vue
@@ -1,13 +1,13 @@
 <template>
 	<DataTable ref="table" fa :data="data" :columns="columns" :next="next" class="CustomProcessPanel">
 		<template slot="toolbar">
-			<button title="Add new custom process" @click="addProcessFromScript" v-show="supportsCreate" :disabled="!this.hasProcess"><i class="fas fa-plus"></i> Add</button>
+			<AsyncButton title="Add new custom process" :fn="addProcessFromScript" v-show="supportsCreate" :disabled="!this.hasProcess" fa confirm icon="fas fa-plus">Add</AsyncButton>
 			<SyncButton v-if="supportsList" :name="plualizedName" :sync="reloadData" />
 		</template>
 		<template #actions="p">
-			<button title="Details" @click="processInfo(p.row)" v-show="supportsRead"><i class="fas fa-info"></i></button>
-			<button title="Edit process" @click="showInEditor(p.row)" v-show="supportsRead"><i class="fas fa-project-diagram"></i></button>
-			<button title="Delete" @click="deleteProcess(p.row)" v-show="supportsDelete"><i class="fas fa-trash"></i></button>
+			<AsyncButton title="Details" :fn="() => processInfo(p.row)" v-show="supportsRead" fa icon="fas fa-info"></AsyncButton>
+			<AsyncButton title="Edit process" confirm :fn="() => showInEditor(p.row)" v-show="supportsRead" fa icon="fas fa-project-diagram"></AsyncButton>
+			<AsyncButton title="Delete" :fn="() => deleteProcess(p.row)" v-show="supportsDelete" fa icon="fas fa-trash"></AsyncButton>
 		</template>
 	</DataTable>
 </template>
@@ -16,6 +16,7 @@
 import EventBusMixin from './EventBusMixin';
 import WorkPanelMixin from './WorkPanelMixin';
 import SyncButton from './SyncButton.vue';
+import AsyncButton from '@openeo/vue-components/components/internal/AsyncButton.vue';
 import Utils from '../utils.js';
 import { UserProcess } from '@openeo/js-client';
 
@@ -23,6 +24,7 @@ export default {
 	name: 'CustomProcessPanel',
 	mixins: [WorkPanelMixin('userProcesses', 'custom process', 'custom processes', false), EventBusMixin],
 	components: {
+		AsyncButton,
 		SyncButton
 	},
 	data() {
@@ -31,15 +33,18 @@ export default {
 				id: {
 					name: 'ID',
 					primaryKey: true,
-					sort: 'asc'
+					sort: 'asc',
+					width: '30%'
 				},
 				summary: {
-					name: 'Summary'
+					name: 'Summary',
+					width: '50%'
 				},
 				actions: {
 					name: 'Actions',
 					filterable: false,
-					sort: false
+					sort: false,
+					width: '20%'
 				}
 			}
 		};
@@ -53,8 +58,8 @@ export default {
 		this.listen('replaceProcess', this.replaceProcess);
 	},
 	methods: {
-		showInEditor(process) {
-			this.refreshElement(process, updatedProcess => this.broadcast('editProcess', updatedProcess));
+		async showInEditor(process) {
+			await this.refreshElement(process, updatedProcess => this.broadcast('editProcess', updatedProcess));
 		},
 		getIdField(value = undefined) {
 			return {
@@ -69,7 +74,7 @@ export default {
 				default: null
 			};
 		},
-		addProcessFromScript() {
+		async addProcessFromScript() {
 			let fields = [];
 			if (!this.process.id) {
 				fields.push(this.getIdField());
@@ -90,13 +95,17 @@ export default {
 				});
 				fields.push(this.getIdField(this.process.id));
 			}
-			let store = data => this.addProcess(this.normalize(this.process, data));
-			if (fields.length > 0) {
-				this.broadcast('showDataForm', 'Store a new custom process', fields, store);
-			}
-			else {
-				store();
-			}
+			return new Promise((resolve, reject) => {
+				let store = data => this.addProcess(this.normalize(this.process, data))
+					.then(ok => ok ? resolve() : reject())
+					.catch(reject);
+				if (fields.length > 0) {
+					this.broadcast('showDataForm', 'Store a new custom process', fields, store);
+				}
+				else {
+					store();
+				}
+			});
 		},
 		normalize(process, data = {}) {
 			return Object.assign(
@@ -105,9 +114,14 @@ export default {
 				data
 			);
 		},
-		addProcess(process) {
-			this.create([process.id, process])
-				.catch(error => Utils.exception(this, error, 'Store Process Error' + (process.id ? `: ${process.id}` : '')));
+		async addProcess(process) {
+			try {
+				await this.create([process.id, process]);
+				return true;
+			} catch (error) {
+				Utils.exception(this, error, 'Store Process Error' + (process.id ? `: ${process.id}` : ''));
+				return false;
+			};
 		},
 		processInfo(process) {
 			this.broadcast('showProcess', process);
@@ -125,19 +139,16 @@ export default {
 				Utils.exception(this, error, 'Update Process Error' + (process.id ? `: ${process.id}` : ''));
 			}
 		},
-		deleteProcess(process) {
+		async deleteProcess(process) {
 			if (!confirm(`Do you really want to delete the process "${Utils.getResourceTitle(process)}"?`)) {
 				return;
 			}
-			this.delete({data: process})
-				.catch(error => Utils.exception(this, error, 'Delete Process Error' + (process.id ? `: ${process.id}` : '')));
+			try {
+				await this.delete({data: process});
+			} catch (error) {
+				Utils.exception(this, error, 'Delete Process Error' + (process.id ? `: ${process.id}` : ''));
+			}
 		}
 	}
 }
 </script>
-
-<style>
-.CustomProcessPanel .id {
-	width: 25%;
-}
-</style>

--- a/src/components/CustomProcessPanel.vue
+++ b/src/components/CustomProcessPanel.vue
@@ -126,9 +126,14 @@ export default {
 		processInfo(process) {
 			this.broadcast('showProcess', process);
 		},
-		replaceProcess(process, newProcess) {
+		async replaceProcess(process, newProcess, resolve, reject) {
 			if (process instanceof UserProcess) {
-				this.updateMetadata(process, newProcess)
+				try {
+					await this.updateMetadata(process, newProcess);
+					resolve();
+				} catch (error) {
+					reject(error);
+				}
 			}
 		},
 		async updateMetadata(process, data) {

--- a/src/components/CustomProcessPanel.vue
+++ b/src/components/CustomProcessPanel.vue
@@ -1,8 +1,8 @@
 <template>
-	<DataTable ref="table" :data="data" :columns="columns" class="CustomProcessPanel">
+	<DataTable ref="table" fa :data="data" :columns="columns" :next="next" class="CustomProcessPanel">
 		<template slot="toolbar">
 			<button title="Add new custom process" @click="addProcessFromScript" v-show="supportsCreate" :disabled="!this.hasProcess"><i class="fas fa-plus"></i> Add</button>
-			<SyncButton name="custom processes" :sync="() => updateData(true)" />
+			<SyncButton v-if="supportsList" :name="plualizedName" :sync="reloadData" />
 		</template>
 		<template #actions="p">
 			<button title="Details" @click="processInfo(p.row)" v-show="supportsRead"><i class="fas fa-info"></i></button>

--- a/src/components/FilePanel.vue
+++ b/src/components/FilePanel.vue
@@ -1,7 +1,7 @@
 <template>
 	<div id="FilePanel" @dragenter="dropZoneInfo(true)" @dragleave="dropZoneInfo(false)" @drop="uploadFiles" @dragover="allowDrop">
 		<div class="dropZone" v-show="showUploadDropHint">To upload files, drop them here.</div>
-		<DataTable ref="table" :data="data" :columns="columns">
+		<DataTable ref="table" fa :data="data" :columns="columns" :next="next">
 			<template slot="toolbar">
 				<div v-show="supportsCreate" class="upload">
 					<div class="percent" :class="{active: this.uploadProgress > 0}"><div class="used" :class="{error: uploadErrored}" :style="'width: ' + this.uploadProgress + '%; opacity: ' + this.uploadFadeOut"></div></div>
@@ -9,7 +9,7 @@
 						<input type="file" name="uploadUserFile" class="uploadUserFile" ref="uploadUserFile" @change="uploadFiles" multiple>
 					</div>
 				</div>
-				<SyncButton name="files" :sync="() => updateData(true)" />
+				<SyncButton v-if="supportsList" :name="plualizedName" :sync="reloadData" />
 			</template>
 			<template #actions="p">
 				<button title="Download" @click="downloadFile(p.row)" v-show="supportsRead"><i class="fas fa-download"></i></button>
@@ -25,7 +25,7 @@ import SyncButton from './SyncButton.vue';
 import Utils from '../utils.js';
 
 export default {
-  	name: 'FilePanel',
+	name: 'FilePanel',
 	mixins: [WorkPanelMixin('files', 'file', 'files')],
 	components: {
 		SyncButton

--- a/src/components/JobPanel.vue
+++ b/src/components/JobPanel.vue
@@ -1,5 +1,5 @@
 <template>
-	<DataTable ref="table" :data="data" :columns="columns" class="JobPanel">
+	<DataTable ref="table" :data="data" :columns="columns" :hasMore="hasMore" class="JobPanel" @next="nextPage()">
 		<template slot="toolbar">
 			<button title="Add new job for batch processing" @click="createJobFromScript()" v-show="supportsCreate" :disabled="!this.hasProcess"><i class="fas fa-plus"></i> Create Batch Job</button>
 			<button title="Run the process directly and view the results without storing them permanently" @click="executeProcess" v-show="supports('computeResult')" :disabled="!this.hasProcess"><i class="fas fa-play"></i> Run now</button>

--- a/src/components/JobPanel.vue
+++ b/src/components/JobPanel.vue
@@ -1,9 +1,9 @@
 <template>
-	<DataTable ref="table" :data="data" :columns="columns" :hasMore="hasMore" class="JobPanel" @next="nextPage()">
+	<DataTable ref="table" fa :data="data" :columns="columns" :next="next" class="JobPanel">
 		<template slot="toolbar">
 			<button title="Add new job for batch processing" @click="createJobFromScript()" v-show="supportsCreate" :disabled="!this.hasProcess"><i class="fas fa-plus"></i> Create Batch Job</button>
 			<button title="Run the process directly and view the results without storing them permanently" @click="executeProcess" v-show="supports('computeResult')" :disabled="!this.hasProcess"><i class="fas fa-play"></i> Run now</button>
-			<SyncButton v-if="supportsList" name="batch jobs" :sync="() => updateData(true)" />
+			<SyncButton v-if="supportsList" :name="plualizedName" :sync="reloadData" />
 		</template>
 		<template #actions="p">
 			<button title="Details" @click="showJobInfo(p.row)" v-show="supportsRead"><i class="fas fa-info"></i></button>

--- a/src/components/JobPanel.vue
+++ b/src/components/JobPanel.vue
@@ -298,13 +298,20 @@ export default {
 		showLogs(job) {
 			this.broadcast('viewLogs', job);
 		},
-		replaceProcess(job, process) {
+		async replaceProcess(job, process, resolve, reject) {
 			if (job instanceof Job) {
 				if (this.isJobActive(job)) {
 					Utils.error(this, "Can't update process while batch job is running.");
+					reject();
 				}
 				else {
-					this.updateJob(job, {process: process});
+					try {
+						await this.updateJob(job, {process: process});
+						resolve();
+						return;
+					} catch (error) {
+						reject(error)
+					}
 				}
 			}
 		},

--- a/src/components/ServicePanel.vue
+++ b/src/components/ServicePanel.vue
@@ -1,9 +1,9 @@
 <template>
-	<DataTable ref="table" :data="data" :columns="columns" class="ServicePanel">
+	<DataTable ref="table" fa :data="data" :columns="columns" :next="next" class="ServicePanel">
 		<template slot="toolbar">
 			<button title="Add new permanently stored web service" @click="createServiceFromScript()" v-show="supportsCreate" :disabled="!this.hasProcess"><i class="fas fa-plus"></i> Create</button>
 			<button title="Quickly show the process on map without storing it permanently" @click="quickViewServiceFromScript()" v-show="supportsQuickView" :disabled="!this.hasProcess"><i class="fas fa-map"></i> Show on Map</button>
-			<SyncButton name="web services" :sync="() => updateData(true)" />
+			<SyncButton v-if="supportsList" :name="plualizedName" :sync="reloadData" />
 		</template>
 		<template #actions="p">
 			<button title="Details" @click="serviceInfo(p.row)" v-show="supportsRead"><i class="fas fa-info"></i></button>

--- a/src/components/ServicePanel.vue
+++ b/src/components/ServicePanel.vue
@@ -275,9 +275,14 @@ export default {
 				this.broadcast('showModal', 'ServiceInfoModal', {service: updatedService.getAll()});
 			});
 		},
-		replaceProcess(service, process) {
+		async replaceProcess(service, process, resolve, reject) {
 			if (service instanceof Service) {
-				this.updateService(service, {process: process});
+				try {
+					await this.updateService(service, {process: process});
+					resolve();
+				} catch(error) {
+					reject(error);
+				}
 			}
 		},
 		updateTitle(service, newTitle) {

--- a/src/components/SyncButton.vue
+++ b/src/components/SyncButton.vue
@@ -1,5 +1,5 @@
 <template>
-  <AsyncButton fa confirm icon="fas fa-sync" :title="title" :fn="sync" />
+  <AsyncButton fa confirm consistent icon="fas fa-sync" :title="title" :fn="sync" />
 </template>
 
 <script>

--- a/src/components/SyncButton.vue
+++ b/src/components/SyncButton.vue
@@ -1,14 +1,15 @@
 <template>
-	<button :title="title" class="data-sync" @click="update">
-		<i v-if="syncState === true" class="fas fa-check"></i>
-		<i v-else-if="syncState === false" class="fas fa-times"></i>
-		<i v-else class="fas fa-sync"></i>
-	</button>
+  <AsyncButton fa confirm icon="fas fa-sync" :title="title" :fn="sync" />
 </template>
 
 <script>
+import AsyncButton from '@openeo/vue-components/components/internal/AsyncButton.vue';
+
 export default {
 	name: "SyncButton",
+  components: {
+    AsyncButton
+  },
 	props: {
 		name: {
 			type: String,
@@ -19,33 +20,10 @@ export default {
 			required: true
 		}
 	},
-	data() {
-		return {
-			syncState: null
-		};
-	},
 	computed: {
 		title() {
-			return "Refresh list of " + this.name
+			return "Reload list of " + this.name;
 		}
 	},
-	methods: {
-		async update(event) {
-			if (this.syncState !== null) {
-				return;
-			}
-			this.syncState = await this.sync(event);
-			setTimeout(() => this.syncState = null, 3000);
-		}
-	}
-}
+};
 </script>
-
-<style scoped lang="scss">
-.fa-check {
-	color: green;
-}
-.fa-times {
-	color: maroon;
-}
-</style>

--- a/src/components/WorkPanelMixin.js
+++ b/src/components/WorkPanelMixin.js
@@ -8,6 +8,8 @@ export default (namespace, singular, plural, loadInitially = true) => {
 		},
 		data() {
 			return {
+				name: singular,
+				plualizedName: plural,
 				syncTimer: null,
 				lastSyncTime: null
 			};
@@ -23,7 +25,10 @@ export default (namespace, singular, plural, loadInitially = true) => {
 		computed: {
 			...Utils.mapState(namespace, {data: namespace}),
 			...Utils.mapState(namespace, ['pages', 'hasMore']),
-			...Utils.mapGetters(namespace, ['supportsList', 'supportsCreate', 'supportsRead', 'supportsUpdate', 'supportsDelete'])
+			...Utils.mapGetters(namespace, ['supportsList', 'supportsCreate', 'supportsRead', 'supportsUpdate', 'supportsDelete']),
+			next() {
+				return this.hasMore ? this.nextPage : null;
+			}
 		},
 		methods: {
 			...Utils.mapActions(namespace, ['list', 'nextPage', 'create', 'read', 'update', 'delete']),
@@ -61,6 +66,9 @@ export default (namespace, singular, plural, loadInitially = true) => {
 				} catch(error) {
 					Utils.exception(this, error, "Load " + singular + " error");
 				}
+			},
+			async reloadData() {
+				return await this.updateData(true);
 			},
 			async updateData(force = false) {
 				var table = this.getTable();

--- a/src/components/WorkPanelMixin.js
+++ b/src/components/WorkPanelMixin.js
@@ -22,10 +22,11 @@ export default (namespace, singular, plural, loadInitially = true) => {
 		},
 		computed: {
 			...Utils.mapState(namespace, {data: namespace}),
+			...Utils.mapState(namespace, ['pages', 'hasMore']),
 			...Utils.mapGetters(namespace, ['supportsList', 'supportsCreate', 'supportsRead', 'supportsUpdate', 'supportsDelete'])
 		},
 		methods: {
-			...Utils.mapActions(namespace, ['list', 'create', 'read', 'update', 'delete']),
+			...Utils.mapActions(namespace, ['list', 'nextPage', 'create', 'read', 'update', 'delete']),
 			getTable() { // To be overridden
 				return this.$refs && this.$refs.table ? this.$refs.table : null;
 			},

--- a/src/components/modals/CollectionModal.vue
+++ b/src/components/modals/CollectionModal.vue
@@ -1,19 +1,33 @@
 <template>
-	<Modal width="80%" :title="collection.id" @closed="$emit('closed')">
-		<div class="docgen">
-			<Collection :data="collection" />
-			<section class="items" v-if="currentItems">
-				<Items :items="currentItems">
-					<template #item-location="p">
-						<MapExtentViewer :footprint="p.geometry"></MapExtentViewer>
-					</template>
-				</Items>
-				<div class="pagination">
-					<button title="Previous page" @click="paginate(-1)" :disabled="!hasPrevItems"><i class="fas fa-arrow-left"></i> Previous Page</button>
-					<button title="Next page" @click="paginate(1)" :disabled="!hasNextItems">Next Page <i class="fas fa-arrow-right"></i></button>
-				</div>
-			</section>
-		</div>
+	<Modal class="collection" width="80%" height="96%" :title="collection.id" @closed="$emit('closed')">
+		<Tabs id="collection-modal" position="bottom">
+			<Tab id="metadata" name="Overview" icon="fa-info" class="docgen">
+				<Collection :data="collection" />
+			</Tab>
+			<Tab id="items" name="Items" icon="fa-images" class="docgen" @show="showHiddenMap=true" @hide="showHiddenMap=false">
+				<section class="items" v-if="currentItems">
+					<Items :items="currentItems" showMap>
+						<template #map="p">
+							<MapExtentViewer :show="showHiddenMap" ref="overview" :footprint="p.geojson" :fill="false"></MapExtentViewer>
+						</template>
+						<template #after-search-box>
+							<div class="pagination">
+								<AsyncButton title="Previous page" :fn="() => paginate(-1)" :disabled="!hasPrevItems" fa icon="fas fa-arrow-left">Previous Page</AsyncButton>
+								<AsyncButton title="Next page" :fn="() => paginate(1)" :disabled="!hasNextItems" fa icon="fas fa-arrow-right">Next Page</AsyncButton>
+							</div>
+						</template>
+						<template #item-location="p">
+							<MapExtentViewer :show="showHiddenMap" :footprint="p.geometry"></MapExtentViewer>
+						</template>
+					</Items>
+					<div class="pagination">
+						<AsyncButton title="Previous page" :fn="() => paginate(-1)" :disabled="!hasPrevItems" fa icon="fas fa-arrow-left">Previous Page</AsyncButton>
+						<AsyncButton title="Next page" :fn="() => paginate(1)" :disabled="!hasNextItems" fa icon="fas fa-arrow-right">Next Page</AsyncButton>
+					</div>
+				</section>
+				<section v-else>Individual items are not available for this collection.</section>
+			</Tab>
+		</Tabs>
 	</Modal>
 </template>
 
@@ -22,20 +36,27 @@ import Modal from './Modal.vue';
 import Collection from '../Collection.vue';
 import Utils from '../../utils.js';
 import StacMigrate from '@radiantearth/stac-migrate';
+import AsyncButton from '@openeo/vue-components/components/internal/AsyncButton.vue';
+import Tabs from '@openeo/vue-components/components/Tabs.vue';
+import Tab from '@openeo/vue-components/components/Tab.vue';
 
 export default {
 	name: 'CollectionModal',
 	components: {
+		AsyncButton,
 		MapExtentViewer: () => import('../maps/MapExtentViewer.vue'),
 		Modal,
 		Collection,
-		Items: () => import('@openeo/vue-components/components/Items.vue')
+		Items: () => import('@openeo/vue-components/components/Items.vue'),
+		Tabs,
+		Tab
 	},
 	data() {
 		return {
 			items: [],
 			itemsPage: 0,
-			itemPages: null
+			itemPages: null,
+			showHiddenMap: false
 		};
 	},
 	props: {
@@ -44,7 +65,7 @@ export default {
 		}
 	},
 	computed: {
-		...Utils.mapState(['connection']),
+		...Utils.mapState(['connection', 'pageLimit']),
 		...Utils.mapGetters(['supports']),
 		currentItems() {
 			if (this.items.length >= this.itemsPage) {
@@ -77,7 +98,7 @@ export default {
 		},
 		async nextItems() {
 			if (!this.itemPages) {
-				this.itemPages = await this.connection.listCollectionItems(this.collection.id);
+				this.itemPages = await this.connection.listCollectionItems(this.collection.id, null, null, this.pageLimit);
 			}
 			let items = await this.itemPages.nextPage();
 			items = items.map(item => StacMigrate.item(item, this.collection, false));
@@ -109,7 +130,30 @@ export default {
 .vue-component.items > .searchable-list > h2 {
 	display: block;
 	font-size: 1.4em;
-	margin-top: 1.5em;
 	border-bottom-style: dotted;
+}
+
+.modal.collection {
+	.map-extent {
+		height: 300px;
+	}
+	.modal-content {
+		padding: 0;
+		overflow: hidden;
+		width: 100%;
+		height: 100%;
+	}
+	.items .pagination {
+		margin: 1em 0;
+	}
+	#collection-modal {
+		width: 100%;
+		height: 100%;
+		
+		> .tabsBody > .tabContent {
+			padding: 1em;
+			overflow: auto;
+		}
+	}
 }
 </style>

--- a/src/components/modals/Modal.vue
+++ b/src/components/modals/Modal.vue
@@ -39,6 +39,10 @@ export default {
 			type: String,
 			default: "auto"
 		},
+		height: {
+			type: String,
+			default: "auto"
+		},
 		show: {
 			type: Boolean,
 			default: true
@@ -68,6 +72,9 @@ export default {
 			};
 			if (this.minWidth) {
 				style['min-width'] = this.minWidth;
+			}
+			if (this.height) {
+				style['height'] = this.height;
 			}
 			if (Array.isArray(this.position)) {
 				style.position = 'absolute';

--- a/src/store/files.js
+++ b/src/store/files.js
@@ -3,6 +3,7 @@ import storeFactory from './storeFactory';
 export default storeFactory({
 	namespace: 'files',
 	listFn: 'listFiles',
+	paginateFn: 'paginateFiles',
 	createFn: 'uploadFile',
 	updateFn: 'uploadFile',
 	deleteFn: 'deleteFile',

--- a/src/store/index.js
+++ b/src/store/index.js
@@ -44,6 +44,7 @@ const getDefaultState = () => {
 		processesUpdated: 0,
 		collections: [],
 		processNamespaces: Config.processNamespaces || [],
+		pageLimit: Config.pageLimit,
 	};
 };
 

--- a/src/store/jobs.js
+++ b/src/store/jobs.js
@@ -3,6 +3,7 @@ import storeFactory from './storeFactory';
 export default storeFactory({
 	namespace: 'jobs',
 	listFn: 'listJobs',
+	paginateFn: 'paginateJobs',
 	createFn: 'createJob',
 	updateFn: 'updateJob',
 	deleteFn: 'deleteJob',

--- a/src/store/services.js
+++ b/src/store/services.js
@@ -3,6 +3,7 @@ import storeFactory from './storeFactory';
 export default storeFactory({
 	namespace: 'services',
 	listFn: 'listServices',
+	paginateFn: 'paginateServices',
 	createFn: 'createService',
 	updateFn: 'updateService',
 	deleteFn: 'deleteService',

--- a/src/store/storeFactory.js
+++ b/src/store/storeFactory.js
@@ -79,7 +79,6 @@ export default ({namespace, listFn, paginateFn, createFn, updateFn, deleteFn, re
 			},
 			async list(cx) {
 				const count = cx.state[namespace].length;
-				cx.commit('reset');
 				if (cx.getters.supportsList) {
 					// Pass over existing data so that it can be updated (for all complete entities, only update fields that exist in the new object)
 					// instead of getting replaced, see https://github.com/Open-EO/openeo-web-editor/issues/234
@@ -87,11 +86,13 @@ export default ({namespace, listFn, paginateFn, createFn, updateFn, deleteFn, re
 					if (paginateFn) {
 						const pages = cx.rootState.connection[paginateFn](pageLimit, cx.state[namespace]);
 						const data = await pages.nextPage();
+						cx.commit('reset'); // Keep close to the update to avoid flickering
 						cx.commit('pages', pages);
 						cx.commit('data', data);
 					}
 					else {
 						const data = await cx.rootState.connection[listFn](cx.state[namespace]);
+						cx.commit('reset'); // Keep close to the update to avoid flickering
 						cx.commit('data', data);
 					}
 				}

--- a/src/store/userProcesses.js
+++ b/src/store/userProcesses.js
@@ -4,6 +4,7 @@ import Utils from '../utils';
 export default storeFactory({
 	namespace: 'userProcesses',
 	listFn: 'listUserProcesses',
+	paginateFn: null,
 	createFn: 'setUserProcess',
 	updateFn: 'replaceUserProcess',
 	deleteFn: 'deleteUserProcess',


### PR DESCRIPTION
Implements #331 and #233

Depends on:
- https://github.com/Open-EO/openeo-vue-components/pull/98
- https://github.com/Open-EO/openeo-js-client/pull/65

Basic pagination support for jobs, services and files.

Following "issues" occur:

- [x] If you load more pages, the next automatic or manual refresh sets the whole list back to only show the first page. What I may have to do here to request the actual number of shown elements on refreshes, which means that that's the default page size from that time. Or I need to actually paginate and not just append, but then I need to save the URL for each page, too, so that I can refresh per page.
- [x] It seems like I have to press the "Load more..." button one additional time to remove it although no more results are present
