### PR TITLE
[FIX]: Properly view geojson returned from a backend

### DIFF
--- a/src/formats/format.js
+++ b/src/formats/format.js
@@ -43,6 +43,7 @@ export class Format {
 			this.data = await this.fetchData(connection);
 			this.loaded = true;
 		}
+		return this.data;
 	}
 
 	getData() {


### PR DESCRIPTION
Before this commit, the MapViewer was awaiting on loadData but that function was not returning anything. This was causing the MapViewer to always display an empty map.

This commit simply adds this missing return statement so MapViewer:renderMap can work properly